### PR TITLE
Adding custom jailparams

### DIFF
--- a/src/aquarium.h
+++ b/src/aquarium.h
@@ -67,6 +67,10 @@ typedef struct {
 	bool persist;
 	bool vnet_disable;
 
+	size_t jailparam_count;
+	char** jailparam_keys;
+	char** jailparam_vals;
+
 	// devfs ruleset options
 
 	size_t ruleset_count;
@@ -104,6 +108,7 @@ void aquarium_opts_free(aquarium_opts_t* opts);
 
 void aquarium_opts_set_base_path(aquarium_opts_t* opts, char const* base_path);
 void aquarium_opts_add_ruleset(aquarium_opts_t* opts, uint32_t ruleset);
+void aquarium_opts_add_jailparam(aquarium_opts_t* opts, char* key, char* val);
 
 bool aquarium_db_next_ent(aquarium_opts_t* opts, aquarium_db_ent_t* ent, size_t buf_len, char buf[buf_len], FILE* fp, bool be_dramatic);
 char* aquarium_db_read_pointer_file(aquarium_opts_t* opts, char const* path);

--- a/src/aquarium/aquarium.c
+++ b/src/aquarium/aquarium.c
@@ -17,7 +17,7 @@ static void usage(void) {
 	fprintf(stderr,
 		"usage: %1$s [-r base]\n"
 		"       %1$s [-r base] -c path [-t template] [-k kernel_template]\n"
-		"       %1$s [-r base] [-d rulesets] [-pv] [-h hostname] -e path\n"
+		"       %1$s [-r base] [-d rulesets] [-j jailparams] [-pv] [-h hostname] -e path\n"
 		"       %1$s [-r base] -i path -o image\n"
 		"       %1$s [-r base] -I drive [-t template] [-k kernel_template]\n"
 		"       %1$s [-r base] -l\n"
@@ -248,6 +248,28 @@ static void parse_rulesets(aquarium_opts_t* opts, char* rulesets) {
 	}
 }
 
+static void parse_jailparams(aquarium_opts_t* opts, char* jailparams) {
+	char* tok;
+
+	while ((tok = strsep(&jailparams, ","))) {
+		char* const pre_val = strchr(tok, '=');
+
+		if (pre_val == NULL) {
+			warnx("jailparam '%s' has no equals sign ('='), skipping", tok);
+			continue;
+		}
+
+		*pre_val = '\0';
+		char* val = pre_val + 1;
+
+		if (strcmp(val, "NULL") == 0) {
+			val = NULL;
+		}
+
+		aquarium_opts_add_jailparam(opts, tok, val);
+	}
+}
+
 // main function
 
 typedef int (*action_t) (aquarium_opts_t* opts);
@@ -265,7 +287,7 @@ int main(int argc, char* argv[]) {
 
 	int c;
 
-	while ((c = getopt(argc, argv, "c:e:fh:i:I:k:lo:pr:st:T:vy:")) != -1) {
+	while ((c = getopt(argc, argv, "c:d:e:fh:i:I:j:k:lo:pr:st:T:vy:")) != -1) {
 		// general options
 
 		if (c == 'd') {
@@ -275,6 +297,10 @@ int main(int argc, char* argv[]) {
 
 		else if (c == 'h') {
 			opts->hostname = optarg;
+		}
+
+		else if (c == 'j') {
+			parse_jailparams(opts, optarg);
 		}
 
 		else if (c == 'p') {

--- a/src/lib/enter.c
+++ b/src/lib/enter.c
@@ -503,6 +503,13 @@ int aquarium_enter(aquarium_opts_t* opts, char const* path, aquarium_enter_cb_t 
 			JAILPARAM("persist", NULL)
 		}
 
+		for (size_t i = 0; i < opts->jailparam_count; i++) {
+			char* const key = opts->jailparam_keys[i];
+			char* const val = opts->jailparam_vals[i];
+
+			JAILPARAM(key, val);
+		}
+
 		if (jailparam_set(args, args_len, JAIL_CREATE | JAIL_ATTACH) < 0) {
 			warnx("jailparam_set: %s (%s)", strerror(errno), jail_errmsg);
 			_exit(EXIT_FAILURE);

--- a/src/lib/opts.c
+++ b/src/lib/opts.c
@@ -114,6 +114,11 @@ void aquarium_opts_free(aquarium_opts_t* opts) {
 	TRY_FREE(opts->esp_oem);
 	TRY_FREE(opts->esp_vol_label);
 
+	// jailparams
+
+	TRY_FREE(opts->jailparam_keys);
+	TRY_FREE(opts->jailparam_vals);
+
 	// devfs ruleset options
 
 	TRY_FREE(opts->rulesets);
@@ -147,4 +152,14 @@ void aquarium_opts_set_base_path(aquarium_opts_t* opts, char const* base_path) {
 void aquarium_opts_add_ruleset(aquarium_opts_t* opts, uint32_t ruleset) {
 	opts->rulesets = realloc(opts->rulesets, ++opts->ruleset_count * sizeof *opts->rulesets);
 	opts->rulesets[opts->ruleset_count - 1] = ruleset;
+}
+
+void aquarium_opts_add_jailparam(aquarium_opts_t* opts, char* key, char* val) {
+	opts->jailparam_count++;
+
+	opts->jailparam_keys = realloc(opts->jailparam_keys, opts->jailparam_count * sizeof *opts->jailparam_keys);
+	opts->jailparam_vals = realloc(opts->jailparam_vals, opts->jailparam_count * sizeof *opts->jailparam_vals);
+
+	opts->jailparam_keys[opts->jailparam_count - 1] = key;
+	opts->jailparam_vals[opts->jailparam_count - 1] = val;
 }


### PR DESCRIPTION
Resolves #33 

All works, e.g.:

```console
$ aquarium -d5 -vj allow.mount=true,enforce_statfs=1,allow.mount.tmpfs=true,allow.mount.devfs=true,allow.mount.fdescfs=true,allow.mount.procfs=true,allow.mount.linsysfs=true,allow.mount.linprocfs=true,children.max=100 -e dev
# su
# cd
# aquarium -ve linux
# uname
Linux
```